### PR TITLE
Fixes issue in firefox with element being aligned to the bottom of the element

### DIFF
--- a/symbol.js
+++ b/symbol.js
@@ -49,7 +49,8 @@ var Symbol = React.createClass({
         return D.span(
             {
                 style: {
-                    position: 'relative'
+                    position: 'relative',
+                    display: 'inline-block'
                 }
             },
             // Have to render this transparent spacer span to mitigate the issue


### PR DESCRIPTION
![screen shot 2016-01-20 at 9 03 52 am](https://cloud.githubusercontent.com/assets/2182637/12433414/0abb5dfe-bf55-11e5-988e-c55842954c92.png)

If an element has a large line height (in this case `50px`) then on load in firefox the element will be positioned at the bottom of the element. The issue is resolved after the first transition. 

Adding a `display: inline-block` to the containing element fixes the issue. 

Tested in firefox, safari and chrome. 
