### PR TITLE
`React.createClass` is deprecated and will be removed in version 16

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,13 +1,14 @@
 var React = require('react');
 var render = require('react-dom').render;
 var moment = require('moment');
+var createReactClass = require('create-react-class');
 
 var D = React.DOM;
 
 var TransitiveNumber = require('..');
 var transitiveNumber = React.createFactory(TransitiveNumber);
 
-var App = React.createClass({
+var App = createReactClass({
     getInitialState: function() {
         return {
             time: 0,

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 var React = require('react');
 var D = React.DOM;
+var createReactClass = require('create-react-class');
 
 var Symbol = require('./symbol');
 var symbol = React.createFactory(Symbol);
 
-var TransitiveNumber = React.createClass({
+var TransitiveNumber = createReactClass({
     getDefaultProps: function() {
         return {
             className: null,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
+    "create-react-class": "^15.5.0",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },

--- a/symbol.js
+++ b/symbol.js
@@ -1,11 +1,12 @@
 var React = require('react');
 var D = React.DOM;
 var findDOMNode = require('react-dom').findDOMNode
+var createReactClass = require('create-react-class');
 
 var Transition = require('./transition');
 var transition = React.createFactory(Transition);
 
-var Symbol = React.createClass({
+var Symbol = createReactClass({
     getInitialState: function() {
         return {
             previous: null,

--- a/transition.js
+++ b/transition.js
@@ -1,8 +1,9 @@
 var React = require('react');
 var D = React.DOM;
 var findDOMNode = require('react-dom').findDOMNode
+var createReactClass = require('create-react-class');
 
-var Transition = React.createClass({
+var Transition = createReactClass({
     getInitialState: function() {
         return {
             in: (


### PR DESCRIPTION
React provides a drop-in replacement `create-react-class`